### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/RustyNova016/api_bindium/compare/v0.3.1...v0.4.0) - 2026-04-16
+
+### Added
+
+- added headers_mut
+- addclient response
+- use self on parse trait method
+
+### Other
+
+- *(deps)* update hotpath requirement from 0.14.0 to 0.15.0
+- lints
+- [**breaking**] moved parsers
+- move the error
+
 ## [0.3.1](https://github.com/RustyNova016/api_bindium/compare/v0.3.0...v0.3.1) - 2026-03-04
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api_bindium"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.85.0"
 authors = ["RustyNova"]


### PR DESCRIPTION



## 🤖 New release

* `api_bindium`: 0.3.1 -> 0.4.0 (⚠ API breaking changes)

### ⚠ `api_bindium` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_missing.ron

Failed in:
  enum api_bindium::api_request::error::ApiRequestError, previously in file /tmp/.tmptQFDcm/api_bindium/src/api_request/error.rs:8

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant ApiRequestError::MaxRetriesExceeded 1 -> 2 in /tmp/.tmpfSXV4r/api_bindium/src/error/mod.rs:38
  variant ApiRequestError::JsonParsingError 2 -> 3 in /tmp/.tmpfSXV4r/api_bindium/src/error/mod.rs:47
  variant ApiRequestError::ImageParsingError 3 -> 4 in /tmp/.tmpfSXV4r/api_bindium/src/error/mod.rs:60

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant ApiRequestError:ParsingError in /tmp/.tmpfSXV4r/api_bindium/src/error/mod.rs:23

--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/feature_missing.ron

Failed in:
  feature hotpath-off in the package's Cargo.toml

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/inherent_method_missing.ron

Failed in:
  ApiRequest::send_with_retries_async, previously in file /tmp/.tmptQFDcm/api_bindium/src/api_request/async_funcs/orchestration.rs:63
  ApiRequest::parse_response, previously in file /tmp/.tmptQFDcm/api_bindium/src/api_request/parsing.rs:12
  ApiRequest::send_with_retries, previously in file /tmp/.tmptQFDcm/api_bindium/src/api_request/sync_funcs/orchestration.rs:58
  ApiRequest::send_with_retries_async, previously in file /tmp/.tmptQFDcm/api_bindium/src/api_request/async_funcs/orchestration.rs:63
  ApiRequest::parse_response, previously in file /tmp/.tmptQFDcm/api_bindium/src/api_request/parsing.rs:12
  ApiRequest::send_with_retries, previously in file /tmp/.tmptQFDcm/api_bindium/src/api_request/sync_funcs/orchestration.rs:58

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_parameter_count_changed.ron

Failed in:
  api_bindium::api_request::ApiRequest::set_parser now takes 1 parameters instead of 0, in /tmp/.tmpfSXV4r/api_bindium/src/api_request/mod.rs:114
  api_bindium::ApiRequest::set_parser now takes 1 parameters instead of 0, in /tmp/.tmpfSXV4r/api_bindium/src/api_request/mod.rs:114
  api_bindium::endpoints::EndpointUriBuilder::into_api_request now takes 2 parameters instead of 1, in /tmp/.tmpfSXV4r/api_bindium/src/endpoints/mod.rs:30
  api_bindium::endpoints::EndpointUriBuilder::into_api_request_with_body now takes 3 parameters instead of 2, in /tmp/.tmpfSXV4r/api_bindium/src/endpoints/mod.rs:45

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/module_missing.ron

Failed in:
  mod api_bindium::api_request::parsers::text, previously in file /tmp/.tmptQFDcm/api_bindium/src/api_request/parsers/text.rs:1
  mod api_bindium::api_request::error, previously in file /tmp/.tmptQFDcm/api_bindium/src/api_request/error.rs:1
  mod api_bindium::api_request::parsers, previously in file /tmp/.tmptQFDcm/api_bindium/src/api_request/parsers/mod.rs:1
  mod api_bindium::api_request::parsers::image, previously in file /tmp/.tmptQFDcm/api_bindium/src/api_request/parsers/image.rs:1
  mod api_bindium::api_request::parsing, previously in file /tmp/.tmptQFDcm/api_bindium/src/api_request/parsing.rs:1
  mod api_bindium::api_request::parsers::json, previously in file /tmp/.tmptQFDcm/api_bindium/src/api_request/parsers/json.rs:1
  mod api_bindium::api_request::parsers::bytes, previously in file /tmp/.tmptQFDcm/api_bindium/src/api_request/parsers/bytes.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct api_bindium::api_request::parsers::json::JsonParser, previously in file /tmp/.tmptQFDcm/api_bindium/src/api_request/parsers/json.rs:10
  struct api_bindium::api_request::parsers::text::TextParser, previously in file /tmp/.tmptQFDcm/api_bindium/src/api_request/parsers/text.rs:7
  struct api_bindium::api_request::parsers::image::ImageParser, previously in file /tmp/.tmptQFDcm/api_bindium/src/api_request/parsers/image.rs:9
  struct api_bindium::api_request::parsers::bytes::ByteParser, previously in file /tmp/.tmptQFDcm/api_bindium/src/api_request/parsers/bytes.rs:7

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/trait_missing.ron

Failed in:
  trait api_bindium::api_request::parsers::Parser, previously in file /tmp/.tmptQFDcm/api_bindium/src/api_request/parsers/mod.rs:15
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.0](https://github.com/RustyNova016/api_bindium/compare/v0.3.1...v0.4.0) - 2026-04-16

### Added

- added headers_mut
- addclient response
- use self on parse trait method

### Other

- *(deps)* update hotpath requirement from 0.14.0 to 0.15.0
- lints
- [**breaking**] moved parsers
- move the error
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).