### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/RustyNova016/api_bindium/compare/v0.4.0...v0.5.0) - 2026-05-11
+
+### Added
+
+- add testing json parser
+
+### Fixed
+
+- *(deps)* update rust crate hotpath to 0.16.0
+
+### Other
+
+- Add renovate.json
+- use nix for faster downloads
+- fmt
+- fix clippy hack
+- more lints
+- *(lint)* unused_trait_names
+- *(lint)* return_self_not_must_use
+- *(lint)* redundant_else
+- *(lint)* cast_lossless
+- *(lint)* std_instead_of_core
+
 ## [0.4.0](https://github.com/RustyNova016/api_bindium/compare/v0.3.1...v0.4.0) - 2026-04-16
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api_bindium"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.85.0"
 authors = ["RustyNova"]


### PR DESCRIPTION



## 🤖 New release

* `api_bindium`: 0.4.0 -> 0.5.0 (⚠ API breaking changes)

### ⚠ `api_bindium` breaking changes

```text
--- failure feature_not_enabled_by_default: package feature is not enabled by default ---

Description:
A feature is no longer enabled by default for this package. This will break downstream crates which rely on the package's default features and require the functionality of this feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove-another
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/feature_not_enabled_by_default.ron

Failed in:
  feature sync in the package's Cargo.toml

--- failure method_requires_different_generic_type_params: method now requires a different number of generic type parameters ---

Description:
A method now requires a different number of generic type parameters than it used to. Uses of this method that supplied the previous number of generic types will be broken.
        ref: https://doc.rust-lang.org/reference/items/generics.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/method_requires_different_generic_type_params.ron

Failed in:
  api_bindium::api_request::ApiRequest::set_parser takes 2 generic types instead of 1, in /tmp/.tmpFOhzw1/api_bindium/src/api_request/mod.rs:121
  api_bindium::ApiRequest::set_parser takes 2 generic types instead of 1, in /tmp/.tmpFOhzw1/api_bindium/src/api_request/mod.rs:121
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.0](https://github.com/RustyNova016/api_bindium/compare/v0.4.0...v0.5.0) - 2026-05-11

### Added

- add testing json parser

### Fixed

- *(deps)* update rust crate hotpath to 0.16.0

### Other

- Add renovate.json
- use nix for faster downloads
- fmt
- fix clippy hack
- more lints
- *(lint)* unused_trait_names
- *(lint)* return_self_not_must_use
- *(lint)* redundant_else
- *(lint)* cast_lossless
- *(lint)* std_instead_of_core
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).